### PR TITLE
Chore/stimulus setup

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,4 +1,5 @@
 import { Application } from "@hotwired/stimulus"
+import "./controllers"
 
 const application = Application.start()
 
@@ -7,3 +8,6 @@ application.debug = false
 window.Stimulus   = application
 
 export { application }
+
+
+

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,13 +1,12 @@
+import "@hotwired/turbo-rails"
+import "controllers"
+
 import { Application } from "@hotwired/stimulus"
-import "./controllers"
 
 const application = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
-window.Stimulus   = application
+window.Stimulus = application
 
 export { application }
-
-
-

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -2,6 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    this.element.textContent = "Hello World!"
+    this.element.textContent = "THE STIMULUS WORKS"
   }
 }

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,2 +1,5 @@
 <h1>MyPomo</h1>
 <p>Single-page home is working!!! yay!</p>
+
+<div data-controller="hello">Stimulus check</div>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+    <%= javascript_importmap_tags %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -19,7 +20,6 @@
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
-    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
+

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,4 +7,3 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
-


### PR DESCRIPTION
Closes issue #31 

## Summary
Adds Hotwire Stimulus setup and verifies controllers are correctly imported with Importmap.

## Why
We need Stimulus so the Pomodoro timer and other interactive behavior can run on the one-page dashboard.  

**What is Hotwire Stimulus?**  
Stimulus is a lightweight JavaScript framework that ships with Rails as part of Hotwire. It lets us attach small “brains” (controllers) to our HTML using `data-controller` attributes. These controllers make it easy to handle UI behavior like timers, form updates, or modal dialogs without leaving Rails’ conventions.  
Closes #<issue-number-for-stimulus-setup>

